### PR TITLE
Add `do_lower_case=False` on tokenizer

### DIFF
--- a/Pyserini+SciBERT_on_COVID_19_Demo.ipynb
+++ b/Pyserini+SciBERT_on_COVID_19_Demo.ipynb
@@ -195,7 +195,7 @@
       "source": [
         "from transformers import *\n",
         "\n",
-        "tokenizer = AutoTokenizer.from_pretrained('allenai/scibert_scivocab_cased')\n",
+        "tokenizer = AutoTokenizer.from_pretrained('allenai/scibert_scivocab_cased', do_lower_case=False)\n",
         "model = AutoModel.from_pretrained('allenai/scibert_scivocab_cased')"
       ],
       "execution_count": 7,


### PR DESCRIPTION
Hi:)

As I know, when using `cased model` for BertTokenizer, `do_lower_case=False` should be given as an additional argument.

```python
# Tested with transformers==2.5.1
>>> from transformers import *
>>> tokenizer = AutoTokenizer.from_pretrained('allenai/scibert_scivocab_cased')
>>> tokenizer.tokenize("Hello World")
['hel', '##lo', 'world']
>>> tokenizer = AutoTokenizer.from_pretrained('allenai/scibert_scivocab_cased', do_lower_case=False)
>>> tokenizer.tokenize("Hello World")
['Hel', '##lo', 'World']
```
I couldn't find the issue tab, so I've reported this one as PR.

Can you please check this one? Thank you for sharing the great repo:)